### PR TITLE
통화 상태 확인 후 녹음 서비스 제공

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,7 @@ android {
         implementation(libs.androidx.activity)
         implementation(libs.androidx.constraintlayout)
         testImplementation(libs.junit)
+        testImplementation(libs.coroutine)
         androidTestImplementation(libs.androidx.junit)
         androidTestImplementation(libs.androidx.espresso.core)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,28 +2,29 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.settings.MANAGE_ALL_FILES_ACCESS_PERMISSION"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.settings.MANAGE_ALL_FILES_ACCESS_PERMISSION" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <!--    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />-->
+    <!--    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />-->
+    <!--    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />-->
 
     <application
+        package="com.example.fishingcatch0403_tester"
         android:allowBackup="true"
-        android:requestLegacyExternalStorage="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@drawable/logo"
         android:label="@string/app_name"
+        android:requestLegacyExternalStorage="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.FishingCatch0403"
-        package= "com.example.fishingcatch0403_tester"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"
@@ -40,7 +41,25 @@
         <activity
             android:name=".fishingcatch0403.fragments.manager.SplashActivity"
             android:exported="true"
-            android:theme="@style/SplashTheme"/>
+            android:theme="@style/SplashTheme" />
+
+        <receiver
+            android:name="com.example.fishingcatch0403.call_state.CallStateReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.PHONE_STATE" />
+                <action android:name="Alarm.on" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.NEW_OUTGOING_CALL" />
+            </intent-filter>
+        </receiver>
+
+        <service
+            android:name="com.example.fishingcatch0403.call_state.CallService"
+            android:enabled="true"
+            android:exported="false" />"
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/fishingcatch0403/MainActivity.kt
+++ b/app/src/main/java/com/example/fishingcatch0403/MainActivity.kt
@@ -21,8 +21,12 @@ class MainActivity : AppCompatActivity() {
 
     // 필요한 권한들을 문자열로 선언합니다.
     private val recordPermission = android.Manifest.permission.RECORD_AUDIO
-    private val storagePermission = android.Manifest.permission.WRITE_EXTERNAL_STORAGE
-    private val readPermission = android.Manifest.permission.READ_EXTERNAL_STORAGE
+    private val statePermission = android.Manifest.permission.READ_PHONE_STATE
+    private val audioPermission = android.Manifest.permission.READ_MEDIA_AUDIO
+    private val contactPermission = android.Manifest.permission.READ_CONTACTS
+
+//    private val storagePermission = android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+//    private val readPermission = android.Manifest.permission.READ_EXTERNAL_STORAGE
 
     // 뷰 바인딩을 위한 변수 선언. 나중에 초기화됩니다.
     private lateinit var binding: ActivityMainBinding
@@ -90,16 +94,23 @@ class MainActivity : AppCompatActivity() {
         // 각 권한이 승인되었는지 확인합니다.
         val isRecordOK = ContextCompat.checkSelfPermission(this, recordPermission) ==
                 PackageManager.PERMISSION_GRANTED
-        val isStorageOK = ContextCompat.checkSelfPermission(this, storagePermission) ==
+        val isStateOK = ContextCompat.checkSelfPermission(this, statePermission) ==
                 PackageManager.PERMISSION_GRANTED
-        val isReadOK = ContextCompat.checkSelfPermission(this, readPermission) ==
+        val isStorageOK = ContextCompat.checkSelfPermission(this, audioPermission) ==
+                PackageManager.PERMISSION_GRANTED
+        val contactOK = ContextCompat.checkSelfPermission(this, contactPermission) ==
                 PackageManager.PERMISSION_GRANTED
 
+//        val isStorageOK = ContextCompat.checkSelfPermission(this, storagePermission) ==
+//                PackageManager.PERMISSION_GRANTED
+//        val isReadOK = ContextCompat.checkSelfPermission(this, readPermission) ==
+//                PackageManager.PERMISSION_GRANTED
+
         // 하나라도 거부된 권한이 있다면, 사용자에게 권한 요청을 합니다.
-        if (!isRecordOK || !isStorageOK || !isReadOK) {
+        if (!isRecordOK || !isStorageOK || !isStateOK || !contactOK) {
             ActivityCompat.requestPermissions(
                 this,
-                arrayOf(recordPermission, storagePermission, readPermission), 1000
+                arrayOf(recordPermission, audioPermission, statePermission, contactPermission), 1000
             )
         }
     }

--- a/app/src/main/java/com/example/fishingcatch0403/MainViewModel.kt
+++ b/app/src/main/java/com/example/fishingcatch0403/MainViewModel.kt
@@ -43,7 +43,7 @@ data class AnalyzedResult(
 
 
 sealed class State<out T> {
-    object Loading : State<Nothing>()
+    data object Loading : State<Nothing>()
     data class Error(val throwable: Throwable?) : State<Nothing>()
     data class Success<T>(val result: T) : State<T>()
 }
@@ -96,22 +96,6 @@ class MainViewModel : ViewModel() {
             }.onFailure {
                 _recordState.value = State.Error(it)
             }
-        }
-    }
-
-    private suspend fun convertM4aToWav(inputPath: String, outputPath: String): Boolean {
-        // FFmpeg를 사용하여 m4a 파일을 wav 파일로 변환
-        return withContext(Dispatchers.IO) {
-            // FFmpeg 명령어를 사용하여 m4a 파일을 wav 파일로 변환
-            val command = arrayOf(
-                "-i", inputPath, "-acodec", "pcm_s16le", "-ar", "44100", "-ac", "2", outputPath
-            )
-            val executionResult = FFmpeg.execute(command)   // FFmpeg 명령어 실행
-            if (executionResult != 0) { // 명령어 실행 실패 시 로그 출력
-                val log = Config.getLastCommandOutput()
-                Log.e("FFmpeg", "커맨드 입력 실패: $log")
-            }
-            executionResult == 0 // 0이면 성공, 그 외는 실패
         }
     }
 

--- a/app/src/main/java/com/example/fishingcatch0403/call_state/CallService.kt
+++ b/app/src/main/java/com/example/fishingcatch0403/call_state/CallService.kt
@@ -1,0 +1,136 @@
+package com.example.fishingcatch0403.call_state
+
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.database.Cursor
+import android.media.AudioManager
+import android.media.MediaRecorder
+import android.os.IBinder
+import android.provider.ContactsContract
+import android.util.Log
+import java.util.Date
+
+private var mediaRecorder: MediaRecorder? = null
+private var isRecording = false
+private var recordingFilePath = ""
+
+class CallService : Service() {
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        intent?.let {
+            val phoneNumber = it.getStringExtra("phoneNumber")
+            Log.d("[APP] CallService", "CallService 시작: $phoneNumber")
+
+            phoneNumber?.let { number ->
+                // 주소록에 없는 번호인지 확인
+                if (!isNumInContacts(this, number)) {
+                    startRecording(this, number)
+                } else {
+                    Log.d("[APP] CallService", "연락처에 등록된 번호")
+                    stopSelf() // 녹음할 필요가 없으므로 서비스 중지
+                }
+            }
+        }
+        return START_NOT_STICKY // 서비스는 강제로 종료된 후 자동으로 재시작되지 않음
+    }
+
+    override fun onBind(intent: Intent): IBinder? {
+        return null // 바인딩 하지 않기 때문에 null 반환
+    }
+
+    override fun onCreate() {
+        Log.d("[APP] CallService", "CallService 생성")
+        super.onCreate()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        stopRecording() // 서비스 종료 시 녹음 중지
+        Log.d("[APP] CallService", "CallService 종료")
+    }
+
+    private fun isNumInContacts(context: Context, phoneNumber: String): Boolean {
+        val contentResolver = context.contentResolver
+        val uri = ContactsContract.CommonDataKinds.Phone.CONTENT_URI
+
+        val projection = arrayOf(
+            ContactsContract.CommonDataKinds.Phone.NUMBER
+        )
+
+        // 주소록의 모든 번호를 조회
+        val cursor: Cursor? = contentResolver.query(
+            uri,
+            projection,
+            null,
+            null,
+            null
+        )
+
+        cursor?.use {
+            val numberIndex = cursor.getColumnIndex(ContactsContract.CommonDataKinds.Phone.NUMBER)
+            while (cursor.moveToNext()) {
+                val contactNumber = cursor.getString(numberIndex)
+
+                // 전화번호를 동일한 형식으로 비교하기 위한 공백 및 하이픈 제거
+                val normalizedContactNumber = contactNumber.replace(Regex("[^\\d]"), "")
+                val normalizedIncomingPhoneNumber = phoneNumber.replace(Regex("[^\\d]"), "")
+
+                // 연락처에 저장된 번호와 수신된 번호가 동일한지 비교
+                if (normalizedContactNumber == normalizedIncomingPhoneNumber) {
+                    return true // 연락처에 저장된 번호와 수신 번호가 일치하면 true 반환
+                }
+            }
+        }
+        return false    // 연락처에 저장된 번호와 일치하는 번호가 없다면 false 반환
+    }
+
+    private fun startRecording(context: Context, phoneNumber: String) {
+        if (!isRecording) {
+            try {
+                val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+                audioManager.requestAudioFocus(
+                    null,
+                    AudioManager.STREAM_VOICE_CALL,
+                    AudioManager.AUDIOFOCUS_GAIN_TRANSIENT
+                )
+
+                mediaRecorder = MediaRecorder()
+                mediaRecorder?.apply {
+                    setAudioSource(MediaRecorder.AudioSource.VOICE_COMMUNICATION)
+                    setOutputFormat(MediaRecorder.OutputFormat.MPEG_4) // M4A 파일 형식
+                    setAudioEncoder(MediaRecorder.AudioEncoder.AAC) // AAC 인코더 사용
+                    setAudioSamplingRate(44100) // 샘플링 레이트 설정
+                    setAudioEncodingBitRate(128000) // 비트레이트 설정 (128kbps 권장)
+                    recordingFilePath =
+                        context.getExternalFilesDir(null)?.absolutePath + "/Recordings/Call/Recording_Call" + phoneNumber + "${Date().time}.m4a"
+                    setOutputFile(recordingFilePath)
+
+                    prepare()
+                    start()
+                    isRecording = true
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                Log.e("[APP] CallRecording", "녹음 시작 실패: ${e.message}")
+            }
+        }
+    }
+
+    private fun stopRecording() {
+        if (isRecording) {
+            try {
+                mediaRecorder?.apply {
+                    stop()
+                    reset()
+                    release()
+                    isRecording = false
+                    Log.d("[APP] CallRecording", "녹음 종료: $recordingFilePath")
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                Log.e("[APP] CallRecording", "녹음 종료 실패: ${e.message}")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/fishingcatch0403/call_state/CallStateReceiver.kt
+++ b/app/src/main/java/com/example/fishingcatch0403/call_state/CallStateReceiver.kt
@@ -1,0 +1,106 @@
+package com.example.fishingcatch0403.call_state
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.telephony.TelephonyManager
+import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+private var phoneState = ""
+private var foundPhoneNumber = false
+private var onCalled = false
+private var isCallServiceStart = false
+const val INCOMING_NUMBER = TelephonyManager.EXTRA_INCOMING_NUMBER
+
+
+class CallStateReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == "android.intent.action.PHONE_STATE") {
+            intent.getStringExtra(TelephonyManager.EXTRA_STATE)?.let { currentState ->
+                if (phoneState != currentState) {
+                    foundPhoneNumber = false
+                    phoneState = currentState
+                }
+                if (foundPhoneNumber.not()) {
+                    when (phoneState) {
+                        // 통화 수신
+                        TelephonyManager.EXTRA_STATE_RINGING -> {
+                            Log.d("[APP] CallState", "통화수신")
+                            intent.getStringExtra(INCOMING_NUMBER)?.let { phoneNumber ->
+                                goAsync(Dispatchers.IO) {
+                                    if (isCallServiceStart.not()) {
+                                        startCallService(context, phoneNumber)
+                                        isCallServiceStart = true
+                                    }
+                                    foundPhoneNumber = true
+                                }
+                            }
+                        }
+
+                        // 통화 진행
+                        TelephonyManager.EXTRA_STATE_OFFHOOK -> {
+                            Log.d("[APP] CallState", "통화진행")
+                            intent.getStringExtra(INCOMING_NUMBER)?.run {
+                                onCalled = true
+                                foundPhoneNumber = true
+                            }
+                        }
+
+                        // 통화 거절 or 종료
+                        TelephonyManager.EXTRA_STATE_IDLE -> {
+                            Log.d("[APP] CallState", "통화종료")
+                            intent.getStringExtra(INCOMING_NUMBER)?.let { incomingNumber ->
+                                if (isCallServiceStart) {
+                                    stopCallService(context)
+                                    isCallServiceStart = false
+                                    if (onCalled) {
+
+                                    }
+                                }
+                                onCalled = false
+                                foundPhoneNumber = true
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun startCallService(context: Context, phoneNumber: String) {
+    val intent = Intent(context, CallService::class.java)
+    intent.putExtra("phoneNumber", phoneNumber)
+    context.startService(intent)
+}
+
+private fun stopCallService(context: Context) {
+    val intent = Intent(
+        context, CallService::class.java
+    )
+    context.stopService(intent)
+}
+
+
+private fun BroadcastReceiver.goAsync(
+    context: CoroutineContext = EmptyCoroutineContext,
+    block: suspend CoroutineScope.() -> Unit
+) {
+    val pendingResult = goAsync()
+    @OptIn(DelicateCoroutinesApi::class) // Must run globally; there's no teardown callback.
+    GlobalScope.launch(context) {
+        try {
+            block()
+        } finally {
+            pendingResult.finish()
+        }
+    }
+}


### PR DESCRIPTION
- measureTime을 통해, 처리 시간 체크 진행 (MainViewModel.kt:129)
- 캐시 폴더에 파일이 삭제되지 않고 지속적으로 남아 stt시 오류 발생한 것을 해결
- CallStateReceiver와 CallService를 사용하여 통화 상태를 확인하여 통화 수신 시에는 서비스를 제공하지 않고 통화 진행 시에 녹음 서비스 제공(연락처에 등록되지 않은 번호일 경우), 통화 종료시 녹음 서비스 종료

* 당장 해야 할 것

1) stt 결과물에 대한 분석 기능 추가하기

2) 로딩 바 구성하기

3) 분석 결과에 대한 결과 데이터 레이아웃 구성 및 추가

4) ROOM DB를 이용해서, 분석 결과 데이터 캐싱하고, 보여주기.