### PR TITLE
CallService로 통화 녹음 서비스 제공

### DIFF
--- a/app/src/main/java/com/example/fishingcatch0403/call_state/CallStateReceiver.kt
+++ b/app/src/main/java/com/example/fishingcatch0403/call_state/CallStateReceiver.kt
@@ -74,33 +74,34 @@ class CallStateReceiver : BroadcastReceiver() {
             }
         }
     }
-}
-
-private fun startCallService(context: Context, phoneNumber: String) {
-    val intent = Intent(context, CallService::class.java)
-    intent.putExtra("phoneNumber", phoneNumber)
-    context.startService(intent)
-}
-
-private fun stopCallService(context: Context) {
-    val intent = Intent(
-        context, CallService::class.java
-    )
-    context.stopService(intent)
-}
 
 
-private fun BroadcastReceiver.goAsync(
-    context: CoroutineContext = EmptyCoroutineContext,
-    block: suspend CoroutineScope.() -> Unit
-) {
-    val pendingResult = goAsync()
-    @OptIn(DelicateCoroutinesApi::class) // Must run globally; there's no teardown callback.
-    GlobalScope.launch(context) {
-        try {
-            block()
-        } finally {
-            pendingResult.finish()
+    private fun startCallService(context: Context, phoneNumber: String) {
+        val intent = Intent(context, CallService::class.java)
+        intent.putExtra("phoneNumber", phoneNumber)
+        context.startService(intent)
+    }
+
+    private fun stopCallService(context: Context) {
+        val intent = Intent(
+            context, CallService::class.java
+        )
+        context.stopService(intent)
+    }
+
+
+    private fun BroadcastReceiver.goAsync(
+        context: CoroutineContext = EmptyCoroutineContext,
+        block: suspend CoroutineScope.() -> Unit
+    ) {
+        val pendingResult = goAsync()
+        @OptIn(DelicateCoroutinesApi::class) // Must run globally; there's no teardown callback.
+        GlobalScope.launch(context) {
+            try {
+                block()
+            } finally {
+                pendingResult.finish()
+            }
         }
     }
 }


### PR DESCRIPTION
- measureTime을 통해, 처리 시간 체크 진행 (MainViewModel.kt:129)
- 캐시 폴더에 파일이 삭제되지 않고 지속적으로 남아 stt시 오류 발생한 것을 해결
- CallStateReceiver와 CallService를 사용하여 통화 상태를 확인하여 통화 수신 시에는 서비스를 제공하지 않고 통화 진행 시에 녹음 서비스 제공(연락처에 등록되지 않은 번호일 경우), 통화 종료시 녹음 서비스 종료

* 당장 해야 할 것

1) stt 결과물에 대한 분석 기능 추가하기

2) 로딩 바 구성하기

3) 분석 결과에 대한 결과 데이터 레이아웃 구성 및 추가

4) ROOM DB를 이용해서, 분석 결과 데이터 캐싱하고, 보여주기.