### PR TITLE
HomeFragmemt 코드 일부 수정

### DIFF
--- a/app/src/main/java/com/example/fishingcatch0403/fishingcatch0403/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/example/fishingcatch0403/fishingcatch0403/fragments/HomeFragment.kt
@@ -42,8 +42,8 @@ class HomeFragment : Fragment(){
     private lateinit var convertedWavDataList: MutableList<WavModel>
     private val mainViewModel by viewModels<MainViewModel>() // MainViewModel 객체 생성
 
-    var showLoadingBar = false
-    var showToast = false
+    private var showLoadingBar = false
+    private var showToast = false
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -61,10 +61,10 @@ class HomeFragment : Fragment(){
         mainViewModel.setCredentials(credentials)
 
         collectLatestStateFlow(mainViewModel.recordState) { state ->
-            when (val value = state) {
+            when (state) {
                 is State.Success -> {
                     showToast = false
-                    with(value) {
+                    with(state) {
                         if (::convertedWavDataList.isInitialized) {
                             val new = result.filter { it !in convertedWavDataList }
                             convertedWavDataList.addAll(new)
@@ -129,7 +129,7 @@ class HomeFragment : Fragment(){
         }
     }
 
-    fun <T> Fragment.collectLatestStateFlow(flow: Flow<T>, collector: suspend (T) -> Unit) {
+    private fun <T> Fragment.collectLatestStateFlow(flow: Flow<T>, collector: suspend (T) -> Unit) {
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 flow.collectLatest(collector)


### PR DESCRIPTION
- measureTime을 통해, 처리 시간 체크 진행 (MainViewModel.kt:129)
- 캐시 폴더에 파일이 삭제되지 않고 지속적으로 남아 stt시 오류 발생한 것을 해결
- CallStateReceiver와 CallService를 사용하여 통화 상태를 확인하여 통화 수신 시에는 서비스를 제공하지 않고 통화 진행 시에 녹음 서비스 제공(연락처에 등록되지 않은 번호일 경우), 통화 종료시 녹음 서비스 종료

* 당장 해야 할 것

1) stt 결과물에 대한 분석 기능 추가하기

2) 로딩 바 구성하기

3) 분석 결과에 대한 결과 데이터 레이아웃 구성 및 추가

4) ROOM DB를 이용해서, 분석 결과 데이터 캐싱하고, 보여주기.