### PR TITLE
권한 처리 변경

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,11 +8,17 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
-    <!--    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />-->
-    <!--    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />-->
-    <!--    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />-->
+    <uses-permission
+        android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission
+        android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
+        tools:ignore="ScopedStorage" />
 
     <application
         package="com.example.fishingcatch0403_tester"

--- a/app/src/main/java/com/example/fishingcatch0403/MainViewModel.kt
+++ b/app/src/main/java/com/example/fishingcatch0403/MainViewModel.kt
@@ -57,7 +57,7 @@ class MainViewModel : ViewModel() {
     //모노 오디오 파일로 변환 후, STT 과정을 거쳐, 분석까지 이뤄지는 상황에서의 진행 상태
     private val _transcriptState = MutableStateFlow<State<AnalyzedResult>>(State.Loading)
     val transcriptState get() = _transcriptState.asStateFlow()
-    val settings by lazy {
+    private val settings by lazy {
         SpeechSettings.newBuilder()
             .setCredentialsProvider(FixedCredentialsProvider.create(credentials))
             .build()


### PR DESCRIPTION
- measureTime을 통해, 처리 시간 체크 진행 (MainViewModel.kt:129)
- 캐시 폴더에 파일이 삭제되지 않고 지속적으로 남아 stt시 오류 발생한 것을 해결
- CallStateReceiver와 CallService를 사용하여 통화 상태를 확인하여 통화 수신 시에는 서비스를 제공하지 않고 통화 진행 시에 녹음 서비스 제공(연락처에 등록되지 않은 번호일 경우), 통화 종료시 녹음 서비스 종료

* 당장 해야 할 것

1) stt 결과물에 대한 분석 기능 추가하기

2) 로딩 바 구성하기

3) 분석 결과에 대한 결과 데이터 레이아웃 구성 및 추가

4) ROOM DB를 이용해서, 분석 결과 데이터 캐싱하고, 보여주기.